### PR TITLE
fix: hacs.json domain field + robust async_unload_entry

### DIFF
--- a/custom_components/linked_cards/__init__.py
+++ b/custom_components/linked_cards/__init__.py
@@ -78,9 +78,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Clean up when removing the integration."""
-    if DOMAIN in hass.data:
-        hass.data[DOMAIN]["data"] = {"templates": {}}
-        hass.data[DOMAIN]["loaded"] = False
+    hass.data.pop(DOMAIN, None)
     return True
 
 
@@ -94,9 +92,12 @@ async def _async_setup_once(hass: HomeAssistant) -> None:
     hass.data[DOMAIN] = {"store": store, "data": data, "loaded": True}
 
     www_path = Path(__file__).parent / "www" / "linked-card.js"
-    await hass.http.async_register_static_paths([
-        StaticPathConfig(STATIC_URL, str(www_path), cache_headers=True)
-    ])
+    try:
+        await hass.http.async_register_static_paths([
+            StaticPathConfig(STATIC_URL, str(www_path), cache_headers=True)
+        ])
+    except ValueError:
+        pass  # already registered (e.g. from a previous setup before unload)
     hass.http.register_view(LinkedCardsTemplatesView)
     hass.http.register_view(LinkedCardsTemplateView)
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Linked Cards",
+  "domain": "linked_cards",
   "content_in_root": false,
   "render_readme": true,
   "homeassistant": "2024.6.0"


### PR DESCRIPTION
Closes #12

- Add missing `domain` field to hacs.json (HACS requires this to match integration)
- Fix `async_unload_entry` to properly clear `hass.data` with `pop` 
- Wrap static path registration in `try/except ValueError` so re-registration after reload doesn't crash